### PR TITLE
Antony/edit 4 GitHub workflow gh pages

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -1,0 +1,65 @@
+name: Generate Dynamic Pages
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - .gitignore
+      - mk/README.org
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - .gitignore
+      - mk/README.org
+
+jobs:
+  build:
+    name: "Update Editor's Copy"
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up build environment
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential git emacs python3-pip pandoc
+        sudo pip install xml2rfc
+
+    - name: Generate dynamic pages
+      run: make
+
+    - name: Prepare Deployment Directory
+      run: |
+        mkdir -p deploy
+        cp draft/draft-*latest*.html draft/draft-*latest*.txt deploy/
+        cp README.org deploy/  # Optional: if you want to keep README.org in deploy
+
+    - name: "Convert README.org to index.html : optional step"
+      run: |
+        pandoc README.org -o deploy/index.html
+
+    - name: "Archive Built Drafts : Optional step"
+      uses: actions/upload-artifact@v4
+      with:
+        path: |
+          draft/draft-*latest*.html
+          draft/draft-*latest*.txt
+          index.html
+
+    - name: "Verify Draft and Deploy Directory After make : optional step"
+      run: |
+        echo "Contents of the draft directory:"
+        ls -l draft
+        echo "Contents of the deploy directory:"
+        ls -l deploy
+
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: deploy
+        publish_branch: gh-pages
+        keep_files: true
+        cname: ''
+        allow_empty_commit: false

--- a/README.org
+++ b/README.org
@@ -1,0 +1,22 @@
+#+TITLE: README for EESP Internet Draft
+#+AUTHOR: Antony Antony
+#+DATE: December 6, 2024
+
+This is the working area for the individual Internet-Draft, "EESP IKEv2".
+
+* Introduction
+This README provides information about the Enhanced Encapsulating
+Security Payload (EESP) IKEv2 draft document.
+
+* Laest Copy
+The latest version of the draft in HTML format is at:
+- [[https://klassert.github.io/eesp-ikev2/draft-klassert-ipsecme-eesp-latest.html][Editor's Copy]]
+# above URL, hostnmae, is replaced by .github/workflows/generate.yaml
+# sed -i "s|klassert.github.io/eesp-ikev2|$USERNAME.github.io/$REPO_NAME|g"
+
+* IETF Datatracker Copy of EESP I.D.
+- [[https://datatracker.ietf.org/doc/draft-klassert-ipsecme-eesp/][IETF Datatracker: draft-klassert-ipsecme-eesp]]
+
+* References
+For more detailed information, refer to the following resources:
+- [[https://klassert.github.io/eesp-ikev2/draft-klassert-ipsecme-eesp-ikev2-latest.html][EESP IKEv2 Editor's Copy]]


### PR DESCRIPTION
Hi,
This would help  a casual reader to read Editor's copy on Github via web. Editor's copy might be, from time to time, ahead of datattracker version. I have seen this feature in Markdwown. 

Anything against  it? 

Or any changes to README.org?